### PR TITLE
Fix GitHub user display to show actual user information

### DIFF
--- a/frontend/src/mocks/handlers.ts
+++ b/frontend/src/mocks/handlers.ts
@@ -141,18 +141,7 @@ export const handlers = [
       { id: 2, full_name: "octocat/earth" },
     ]),
   ),
-  http.get("/api/github/user", () => {
-    const user: GitHubUser = {
-      id: 1,
-      login: "octocat",
-      avatar_url: "https://avatars.githubusercontent.com/u/583231?v=4",
-      company: "GitHub",
-      email: "placeholder@placeholder.placeholder",
-      name: "monalisa octocat",
-    };
-
-    return HttpResponse.json(user);
-  }),
+  
   http.post("http://localhost:3001/api/submit-feedback", async () =>
     HttpResponse.json({ statusCode: 200 }, { status: 200 }),
   ),


### PR DESCRIPTION
This PR removes the mock GitHub user data to show the actual user information when making PRs.